### PR TITLE
index page for welcome site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+	<link rel="stylesheet" href="https://openfdem.com/assets/css/styles.css">
+    <meta charset="utf-8">
+    <title>Welcome to OpenFDEM!</title>
+  </head>
+  <body>
+<div class="navbar">
+  <div class='logo'><a href="/"><img src="https://openfdem.com/assets/images/logo-250px.png"></a></div>
+  <div><a href="https://github.com/OpenFDEM">Source (on GitHub)</a></div>
+  <div><a href="https://openfdem.com/html/rst_tutorials/tutorial1_ucs.html">Tutorials</a></div>
+  <div><a href="https://openfdem.com/html/index.html">Documentation</a></div>
+  <a href="https://openfdem.com/gallery.html">Gallery</a>
+</div> 
+<div class="splash">
+	<img src="https://openfdem.com/assets/images/ucs-test.gif">
+	</div>
+<div class="navbar">
+  <div class='logo'><a href="/"><img src="https://openfdem.com/assets/images/logo-250px.png"></a></div>
+  <div><a href="https://github.com/OpenFDEM">Source (on GitHub)</a></div>
+  <div><a href="https://openfdem.com/html/rst_tutorials/tutorial1_ucs.html">Tutorials</a></div>
+  <div><a href="https://openfdem.com/html/index.html">Documentation</a></div>
+  <a href="https://openfdem.com/gallery.html">Gallery</a>
+</div> 
+<div class="about">
+OpenFDEM aims to be a free cross-platform finite and discrete element solver with object-oriented architecture for solving multiscale, multiphase, and multiphysics problems.
+	<div class="demo">
+		<img src="https://openfdem.com/assets/images/insitu_example.png">
+		</div>
+	</div>
+  </body>
+</html>


### PR DESCRIPTION
needs to be all in HTML because there is a .nojekyll file in place. Turning on jekyll wrecks the documentation website, so we can't build this index with jekyll markdown